### PR TITLE
Support composite key for the PrimaryKey decorator

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -5,9 +5,21 @@ import Mutator from '@vuex-orm/core/lib/attributes/contracts/Mutator';
  * Sets the property as the primary key of the model
  */
 export function PrimaryKey() {
-    return (target: Object, propertyName: string | symbol): void => {
-        (target.constructor as any).primaryKey = propertyName;
-    };
+    return (target: any, propertyName: string | symbol) => {
+        if (typeof target.constructor.primaryKey === 'string') {
+            if (target.constructor.primaryKey === propertyName) {
+                return
+            } else {
+                target.constructor.primaryKey = [target.constructor.primaryKey, propertyName]
+            }
+            return
+        }
+        if (target.constructor.primaryKey === 'object' && target.constructor.primaryKey instanceof Array) {
+            target.constructor.primaryKey.push(propertyName)
+            return
+        }
+        target.constructor.primaryKey = propertyName
+    }
 }
 
 /**


### PR DESCRIPTION
- In vuex-orm you can define a composite primary key as `primaryKey = ['userId', 'voteId']` (https://vuex-orm.org/guide/model/defining-models.html#primary-key), so added support for that
- Usage: 
```
{
  @PrimaryKey() @StringField() public userId: string

  @PrimaryKey() @StringField() public voteId: string 
}
```