### PR TITLE
Support composite key for PrimaryKey decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,24 @@ class User extends Model {
 
 In this example the property `uuid` replaces the default `id` property as the primary key.
 
+You can also define a composite primary key by annotating several properties with the `@PrimaryKey` decorator as follows:
+
+```typescript
+import { Model } from '@vuex-orm/core';
+import { OrmModel, PrimaryKey, StringField } from 'vuex-orm-decorators';
+
+@OrmModel('users')
+class User extends Model {
+
+    @PrimaryKey()
+    @StringField() public id!: string;
+    
+    @PrimaryKey()
+    @StringField() public voteId!: string;
+
+}
+```
+
 ### Single Table Inheritance
 
 If your model extends a base model, then STI inheritance needs to be used. The base entity name needs to be provided as

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -49,12 +49,26 @@ function Field(fieldType: Attribute) {
  * Adds the property as the `primary key` of the model
  */
 export function PrimaryKey() {
-    return (target: Object, propertyName: string | symbol): void => {
+    return (target: any, propertyName: string | symbol): void => {
         if (propertyName === 'id') {
             console.warn('[Vuex ORM Decorators] No need using `PrimaryKey` decorator on property `id`. Property `id` is by default the `primaryKey`.');
         }
 
-        (target.constructor as any).primaryKey = propertyName;
+        const symbol = Symbol.for("vuex-orm-decorator:primary-key");
+
+        if (typeof target[symbol] === 'object' && target[symbol] instanceof Array) {
+            target[symbol].push(propertyName)
+        }
+        if (typeof target[symbol] === 'string') {
+            if (target[symbol] !== propertyName) {
+                target[symbol] = [target[symbol], propertyName]
+            }
+        }
+        if (typeof target[symbol] === 'undefined') {
+            target[symbol] = propertyName
+        }
+
+        target.constructor.primaryKey = target[symbol]
     };
 }
 

--- a/test/unit/PrimaryKey.spec.ts
+++ b/test/unit/PrimaryKey.spec.ts
@@ -1,5 +1,5 @@
 import { Model } from '@vuex-orm/core';
-import { NumberField, PrimaryKey, UidField } from '@/attributes';
+import  {NumberField, PrimaryKey, StringField, UidField } from '@/attributes';
 import { OrmModel } from '@/model';
 
 describe('PrimaryKey', () => {
@@ -42,4 +42,34 @@ describe('PrimaryKey', () => {
 
         expect(console.warn).toHaveBeenLastCalledWith('[Vuex ORM Decorators] No need using `PrimaryKey` decorator on property `id`. Property `id` is by default the `primaryKey`.');
     });
+
+    it('supports composite key', () => {
+        @OrmModel('users')
+        class User extends Model {
+            @PrimaryKey()
+            @StringField()
+            public userId!: string;
+
+            @PrimaryKey()
+            @StringField()
+            public voteId!: string;
+        }
+
+        expect(User.primaryKey).toEqual(['userId', 'voteId']);
+    })
+
+    it('supports composite key with the default(id) field', () => {
+        @OrmModel('users')
+        class User extends Model {
+            @PrimaryKey()
+            @StringField()
+            public id!: string;
+
+            @PrimaryKey()
+            @StringField()
+            public voteId!: string;
+        }
+
+        expect(User.primaryKey).toEqual(['id', 'voteId']);
+    })
 });


### PR DESCRIPTION
@TiBianMod Hi! Thank you for reviewing my previous [PR](https://github.com/TiBianMod/vuex-orm-decorators/pull/19) and for your work on the library.  

I updated it, added tests and updated the docs. Please be free to reject it if you believe that it's not needed for the library and having the possibility to set `primaryKey`  static property is enough. 

* In vuex-orm you can define a composite primary key as static primaryKey = ['userId', 'voteId'], so added support for that
* Usage: 
 ```
{
  @PrimaryKey() @StringField() public userId: string

  @PrimaryKey() @StringField() public voteId: string 
}
```